### PR TITLE
[AI-962] Add alternate name (axe) in Location Rest API

### DIFF
--- a/server/src/main/java/org/activityinfo/server/endpoint/rest/LocationsResource.java
+++ b/server/src/main/java/org/activityinfo/server/endpoint/rest/LocationsResource.java
@@ -48,6 +48,9 @@ public class LocationsResource {
             json.writeStartObject();
             json.writeNumberField("id", location.getId());
             json.writeStringField("name", location.getName());
+            if (location.hasAxe()) {
+                json.writeStringField("axe", location.getAxe());
+            }
             if (location.hasCoordinates()) {
                 json.writeNumberField("latitude", location.getLatitude());
                 json.writeNumberField("longitude", location.getLongitude());


### PR DESCRIPTION
This facilitates the pairing of internal ids to FK ids used in third party systems. For example, in the Lebanon reporting DBs our location lists are uploaded and the alternate name is set to the PCode of the site which is our official coding system for the whole country. Including the axe name back in the response allows us to automate the uploading and cleaning of lists without duplicating sites.
